### PR TITLE
Remove the OpenWPM submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "OpenWPM"]
-	path = OpenWPM
-	url = https://github.com/mozilla/OpenWPM.git
-	branch = openwpm-crawler-support
 [submodule "analysis/utils"]
 	path = analysis/utils
 	url = https://github.com/mozilla/openwpm-utils

--- a/deployment/gcp/README.md
+++ b/deployment/gcp/README.md
@@ -88,11 +88,13 @@ Then run:
 ./aws_credentials_as_kubectl_secrets.sh
 ```
 
-## Build and push Docker image to GCR
+## (Optional) Build and push Docker image to GCR
 
-(Optional) If one of [the pre-built OpenWPM Docker images](https://hub.docker.com/r/openwpm/openwpm/tags) are not sufficient:
+If one of [the pre-built OpenWPM Docker images](https://hub.docker.com/r/openwpm/openwpm/tags) are not sufficient:
 ```
-cd ../openwpm-crawler/OpenWPM; docker build -t gcr.io/$PROJECT/openwpm .; cd -
+cd path/to/OpenWPM
+docker build -t gcr.io/$PROJECT/openwpm .
+cd -
 gcloud auth configure-docker
 docker push gcr.io/$PROJECT/openwpm
 ```

--- a/deployment/local/README.md
+++ b/deployment/local/README.md
@@ -28,7 +28,16 @@ you can start it by running `minikube start`.
 Make sure that you have an up to date docker image locally:
 
 ```
-cd ../../OpenWPM; docker build -t openwpm .; cd -
+docker pull openwpm/openwpm
+docker tag openwpm/openwpm openwpm
+```
+
+Alternatively, you can build the image from a local OpenWPM code repository:
+
+```
+cd path/to/OpenWPM
+docker build -t openwpm .
+cd -
 ```
 
 ## Set up a mock S3 service


### PR DESCRIPTION
This submodule seems redundant now when crawler support has landed in master and images are pushed automatically to DockerHub.