### PR TITLE
Overwrite existing aws-config secret if already exists

### DIFF
--- a/deployment/gcp/aws_credentials_as_kubectl_secrets.sh
+++ b/deployment/gcp/aws_credentials_as_kubectl_secrets.sh
@@ -4,11 +4,12 @@ set -e
 AWS_CREDENTIALS_FILE=~/.aws/credentials
 
 if kubectl get secret | grep -q 'aws-config'; then
-  echo Secret aws-config already created. Skipping...
-else
-  aws_access_key_id=$(awk -F "\\\\s*=\\\\s*" '/aws_access_key_id/{print $2}' $AWS_CREDENTIALS_FILE | xargs echo)
-  aws_secret_access_key=$(awk -F "\\\\s*=\\\\s*" '/aws_secret_access_key/{print $2}' $AWS_CREDENTIALS_FILE | xargs echo)
-  kubectl create secret generic aws-config \
-  --from-literal=aws_access_key_id=$aws_access_key_id \
-  --from-literal=aws_secret_access_key=$aws_secret_access_key
+  echo Secret aws-config already created. Overwriting...
+  kubectl delete secret aws-config
 fi
+
+aws_access_key_id=$(awk -F "\\\\s*=\\\\s*" '/aws_access_key_id/{print $2}' $AWS_CREDENTIALS_FILE | xargs echo)
+aws_secret_access_key=$(awk -F "\\\\s*=\\\\s*" '/aws_secret_access_key/{print $2}' $AWS_CREDENTIALS_FILE | xargs echo)
+kubectl create secret generic aws-config \
+--from-literal=aws_access_key_id=$aws_access_key_id \
+--from-literal=aws_secret_access_key=$aws_secret_access_key


### PR DESCRIPTION
Useful when local credentials have been updated