### PR TITLE
Fix high crash rate when crawler is run in Docker

### DIFF
--- a/deployment/gcp/crawl.tmpl.yaml
+++ b/deployment/gcp/crawl.tmpl.yaml
@@ -10,11 +10,18 @@ spec:
     metadata:
       name: openwpm-crawl
     spec:
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
       containers:
       - name: openwpm-crawl
         image: docker.io/openwpm/openwpm:latest
         command: ["python"]
         args: ["crawler.py"]
+        volumeMounts:
+          - mountPath: /dev/shm
+            name: dshm
         env:
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
@@ -47,7 +54,7 @@ spec:
         - name: DWELL_TIME
           value: '10'
         - name: TIMEOUT
-          value: '60'
+          value: '120'
         - name: SENTRY_DSN
           valueFrom:
             secretKeyRef:

--- a/deployment/load_alexa_top_1m_site_list_into_redis.sh
+++ b/deployment/load_alexa_top_1m_site_list_into_redis.sh
@@ -8,6 +8,10 @@ fi
 REDIS_QUEUE_NAME="$1"
 MAX_RANK="$2"
 
+echo -e "\nAttempting to clean up any leftover lists from a previous run..."
+rm top-1m.csv.zip* || true
+rm top-1m.csv* || true
+
 echo -e "\nDownloading and unzipping site list..."
 wget http://s3.amazonaws.com/alexa-static/top-1m.csv.zip
 unzip -o top-1m.csv.zip

--- a/deployment/local/crawl.tmpl.yaml
+++ b/deployment/local/crawl.tmpl.yaml
@@ -9,12 +9,19 @@ spec:
     metadata:
       name: openwpm-crawl
     spec:
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
       containers:
       - name: openwpm-crawl
         image: openwpm
         command: ["python"]
         args: ["crawler.py"]
         imagePullPolicy: Never # allows use of a locally built/tagged docker image
+        volumeMounts:
+          - mountPath: /dev/shm
+            name: dshm
         env:
         - name: AWS_ACCESS_KEY_ID
           value: 'foo'


### PR DESCRIPTION
Need to rebase on #27.

As explored in https://github.com/mozilla/OpenWPM/issues/255, newer versions of Firefox will often crash due to insufficient shared memory. This issue wasn't present in the Firefox 52 branch because we used to set `browser.tabs.remote.autostart` to False, which disables SHM usage by disabling e10s. 

When running a Docker container, the shared memory size can be increased by adding the [argument `--shm-size=2g`](https://bugzilla.mozilla.org/show_bug.cgi?id=1567168#c9). Unfortunately kubernetes doesn't yet support setting the shared memory size (see: https://github.com/kubernetes/kubernetes/issues/28272), nor does it support passing arguments to docker. The current fix is a workaround copied from https://github.com/kubernetes/kubernetes/issues/28272#issuecomment-382649481. 

I ran a 5k site test crawl with this fix using the branch from this PR: https://github.com/mozilla/OpenWPM/pull/473 . For results, see: https://dbc-caf9527b-e073.cloud.databricks.com/#notebook/165717/command/165734.

```
== CRAWL HISTORY ==
Total number of commands submitted:
+-------+-----+
|command|count|
+-------+-----+
|    GET| 4873|
+-------+-----+

Percentage of command failures 0.10%
Percentage of neterrors 6.48%
Percentage of command timeouts 2.85%

Summary of neterrors:
+-----------------+-----+
|            error|count|
+-----------------+-----+
|connectionFailure|   11|
|       netTimeout|  155|
|         netReset|    1|
|     fileNotFound|    1|
|      nssFailure2|    2|
|      dnsNotFound|  146|
+-----------------+-----+


Summary of exceptions:
+--------------------+-----+
|               error|count|
+--------------------+-----+
|NoSuchWindowExcep...|    1|
|InvalidSessionIdE...|    4|
+--------------------+-----+
```

Errors due to crashes still occur, but significantly less frequently. Note that I also had to increase the timeout to 120 seconds. The timeout rate at 60 seconds was ~20% of sites. I'm not sure if this workaround introduces some overhead, or if it's just that the sites that previous crashed FF were resource heavy and thus moved from crashing to timing out after increasing the shared memory size.
